### PR TITLE
Diagnose GitHub Action Workflow Error

### DIFF
--- a/.github/workflows/notion-hugo-deploy.yml
+++ b/.github/workflows/notion-hugo-deploy.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install notion-client python-dotenv pyyaml fs tabulate
+          pip install "notion-client>=2.0.0,<2.5.0" python-dotenv pyyaml fs tabulate
 
       - name: Restore Notion sync state
         uses: actions/cache@v4

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -1,5 +1,5 @@
 # Production dependencies for Notion-Hugo pipeline
-notion-client>=2.0.0
+notion-client>=2.0.0,<2.5.0
 pyyaml>=6.0
 requests>=2.28.0
 python-frontmatter>=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-notion-client>=2.0.0
+notion-client>=2.0.0,<2.5.0
 pyyaml>=6.0
 requests>=2.28.0
 python-frontmatter>=1.0.0

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ from typing import Dict, Any, Optional, List, Tuple
 # 의존성 자동 설치
 def install_dependencies():
     """필요한 의존성 자동 설치"""
-    dependencies = ["notion-client", "python-dotenv", "pyyaml", "fs", "tabulate"]
+    dependencies = ["notion-client>=2.0.0,<2.5.0", "python-dotenv", "pyyaml", "fs", "tabulate"]
 
     for dep in dependencies:
         try:
@@ -850,7 +850,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install notion-client python-dotenv pyyaml fs tabulate
+          pip install "notion-client>=2.0.0,<2.5.0" python-dotenv pyyaml fs tabulate
       
       - name: Sync from Notion
         env:

--- a/vercel_setup.py
+++ b/vercel_setup.py
@@ -6,7 +6,7 @@ from dotenv import load_dotenv
 
 def install_dependencies():
     """Install necessary dependencies if they are not already installed."""
-    dependencies = ["notion-client", "python-dotenv", "pyyaml", "fs", "tabulate"]
+    dependencies = ["notion-client>=2.0.0,<2.5.0", "python-dotenv", "pyyaml", "fs", "tabulate"]
     for dep in dependencies:
         try:
             module_name = dep.replace("-", "_")


### PR DESCRIPTION
notion-client 버전을 2.5.0 미만으로 제한하여 databases.query API 호환성 보장

## 문제
- Notion API 버전 2025-09-03에서 databases.query가 deprecated됨
- notion-client 2.5.0+에서 DatabasesEndpoint.query 메서드 제거됨
- GitHub Actions에서 'DatabasesEndpoint' object has no attribute 'query' 오류 발생

## 해결
- notion-client 버전을 >=2.0.0,<2.5.0으로 제한
- 기존 databases.query API를 계속 사용할 수 있도록 함

## 변경 파일
- requirements.txt
- requirements.prod.txt
- .github/workflows/notion-hugo-deploy.yml
- setup.py
- vercel_setup.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)